### PR TITLE
Fix lab settings saving

### DIFF
--- a/src/scripts/pages/labPage.js
+++ b/src/scripts/pages/labPage.js
@@ -96,7 +96,7 @@ class LabPage extends Page {
         this.searchArray = $.grep(this.searchArray, function (value) {
             return value != key;
         });
-        this.settings.findCustom = this.searchArray.toString();
+        this.settings.findLabEgg = this.searchArray.toString();
 
         $(byebye).parent().remove();
 
@@ -116,7 +116,7 @@ class LabPage extends Page {
         this.typeArray = $.grep(this.typeArray, function (value) {
             return value != key;
         });
-        this.settings.findType = this.typeArray.toString();
+        this.settings.findLabType = this.typeArray.toString();
 
         $(byebye).parent().remove();
 


### PR DESCRIPTION
Using the remove buttons for the lab searches caused the page's settings to reset. Seems there was some copy-pasting from the shelter page without changing the variable names properly.